### PR TITLE
Change getClasspath method

### DIFF
--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/classloader/ClassloaderServiceImpl.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/classloader/ClassloaderServiceImpl.java
@@ -21,17 +21,16 @@ import com.alipay.sofa.ark.common.log.ArkLoggerFactory;
 import com.alipay.sofa.ark.common.util.AssertUtils;
 import com.alipay.sofa.ark.exception.ArkException;
 import com.alipay.sofa.ark.spi.model.Biz;
-import com.alipay.sofa.ark.spi.service.biz.BizManagerService;
-import com.alipay.sofa.ark.spi.service.plugin.PluginManagerService;
 import com.alipay.sofa.ark.spi.model.Plugin;
+import com.alipay.sofa.ark.spi.service.biz.BizManagerService;
 import com.alipay.sofa.ark.spi.service.classloader.ClassloaderService;
+import com.alipay.sofa.ark.spi.service.plugin.PluginManagerService;
+import com.alipay.sofa.ark.spi.tools.RuntimeUtil;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import sun.misc.URLClassPath;
 
 import java.io.File;
 import java.lang.management.ManagementFactory;
-import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.AccessController;
@@ -184,11 +183,8 @@ public class ClassloaderServiceImpl implements ClassloaderService {
 
         List<URL> jdkUrls = new ArrayList<>();
         try {
-            Field ucpField = systemClassloader.getClass().getSuperclass().getDeclaredField("ucp");
-            ucpField.setAccessible(true);
-            URLClassPath urlClassPath = (URLClassPath) ucpField.get(systemClassloader);
             String javaHome = System.getProperty("java.home").replace(File.separator + "jre", "");
-            for (URL url : urlClassPath.getURLs()) {
+            for (URL url : RuntimeUtil.getClasspath(systemClassloader)) {
                 if (url.getPath().startsWith(javaHome)) {
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug(String.format("Find JDK Url: %s", url));

--- a/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/tools/RuntimeUtil.java
+++ b/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/tools/RuntimeUtil.java
@@ -23,7 +23,7 @@ import java.net.URLClassLoader;
  * runtime utils
  *
  * @author joe
- * @version 2018.04.23 10:46
+ * @since 0.3.0
  */
 public class RuntimeUtil {
     /**

--- a/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/tools/RuntimeUtil.java
+++ b/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/tools/RuntimeUtil.java
@@ -1,5 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alipay.sofa.ark.spi.tools;
-
 
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -28,4 +43,3 @@ public class RuntimeUtil {
         }
     }
 }
-

--- a/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/tools/RuntimeUtil.java
+++ b/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/tools/RuntimeUtil.java
@@ -1,0 +1,31 @@
+package com.alipay.sofa.ark.spi.tools;
+
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * 运行时工具
+ *
+ * @author joe
+ * @version 2018.04.23 10:46
+ */
+public class RuntimeUtil {
+    /**
+     * 获取classpath
+     *
+     * @param classLoader ClassLoader
+     * @return ClassLoader对应的classpath
+     */
+    public static URL[] getClasspath(ClassLoader classLoader) {
+        if (classLoader == null) {
+            return new URL[0];
+        }
+        if (classLoader instanceof URLClassLoader) {
+            return ((URLClassLoader) classLoader).getURLs();
+        } else {
+            return getClasspath(classLoader.getParent());
+        }
+    }
+}
+

--- a/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/tools/RuntimeUtil.java
+++ b/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/tools/RuntimeUtil.java
@@ -20,17 +20,17 @@ import java.net.URL;
 import java.net.URLClassLoader;
 
 /**
- * 运行时工具
+ * runtime utils
  *
  * @author joe
  * @version 2018.04.23 10:46
  */
 public class RuntimeUtil {
     /**
-     * 获取classpath
+     * get classpath from ClassLoader
      *
      * @param classLoader ClassLoader
-     * @return ClassLoader对应的classpath
+     * @return classpath
      */
     public static URL[] getClasspath(ClassLoader classLoader) {
         if (classLoader == null) {

--- a/sofa-ark-parent/core/spi/src/test/java/com/alipay/sofa/ark/spi/argument/LaunchCommandTest.java
+++ b/sofa-ark-parent/core/spi/src/test/java/com/alipay/sofa/ark/spi/argument/LaunchCommandTest.java
@@ -78,8 +78,8 @@ public class LaunchCommandTest {
             Assert.assertTrue(launchCommand.getEntryMethodName().equals(method.getName()));
             Assert.assertTrue(launchCommand.getExecutableArkBizJar().equals(fatJarUrl));
             Assert.assertTrue(launchCommand.isTestMode());
-            Assert.assertTrue(launchCommand.getClasspath().length == classpath
-                .split(CommandArgument.CLASSPATH_SPLIT).length);
+            Assert.assertTrue(launchCommand.getClasspath().length == ("".equals(classpath) ? 0
+                : classpath.split(CommandArgument.CLASSPATH_SPLIT).length));
             for (URL url : launchCommand.getClasspath()) {
                 Assert.assertTrue(classpath.contains(url.toExternalForm()));
             }

--- a/sofa-ark-parent/core/spi/src/test/java/com/alipay/sofa/ark/spi/argument/LaunchCommandTest.java
+++ b/sofa-ark-parent/core/spi/src/test/java/com/alipay/sofa/ark/spi/argument/LaunchCommandTest.java
@@ -103,7 +103,6 @@ public class LaunchCommandTest {
 
     }
 
-
     private String getClasspath(URL[] urls) throws Exception {
 
         StringBuilder sb = new StringBuilder();

--- a/sofa-ark-parent/core/spi/src/test/java/com/alipay/sofa/ark/spi/argument/LaunchCommandTest.java
+++ b/sofa-ark-parent/core/spi/src/test/java/com/alipay/sofa/ark/spi/argument/LaunchCommandTest.java
@@ -16,15 +16,13 @@
  */
 package com.alipay.sofa.ark.spi.argument;
 
+import com.alipay.sofa.ark.spi.tools.RuntimeUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import sun.misc.URLClassPath;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.net.URLClassLoader;
 
 /**
  * @author qilong.zql 18/3/9
@@ -42,7 +40,7 @@ public class LaunchCommandTest {
     public void init() {
 
         try {
-            classpath = getClasspath(getURLClassPath(this.getClass().getClassLoader()).getURLs());
+            classpath = getClasspath(RuntimeUtil.getClasspath(this.getClass().getClassLoader()));
             method = MainClass.class.getMethod("main", String[].class);
             fatJarUrl = this.getClass().getClassLoader().getResource("test.jar");
         } catch (Exception ex) {
@@ -105,22 +103,6 @@ public class LaunchCommandTest {
 
     }
 
-    private URLClassPath getURLClassPath(ClassLoader classLoader) throws Exception {
-        try {
-            Field ucpField;
-
-            try {
-                ucpField = classLoader.getClass().getDeclaredField("ucp");
-            } catch (NoSuchFieldException ex) {
-                ucpField = URLClassLoader.class.getDeclaredField("ucp");
-            }
-
-            ucpField.setAccessible(true);
-            return (URLClassPath) ucpField.get(classLoader);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     private String getClasspath(URL[] urls) throws Exception {
 

--- a/sofa-ark-parent/support/ark-support-starter/src/main/java/com/alipay/sofa/ark/support/startup/SofaArkBootstrap.java
+++ b/sofa-ark-parent/support/ark-support-starter/src/main/java/com/alipay/sofa/ark/support/startup/SofaArkBootstrap.java
@@ -17,16 +17,14 @@
 package com.alipay.sofa.ark.support.startup;
 
 import com.alipay.sofa.ark.bootstrap.ClasspathLauncher;
+import com.alipay.sofa.ark.bootstrap.ClasspathLauncher.ClassPathArchive;
+import com.alipay.sofa.ark.common.util.AssertUtils;
+import com.alipay.sofa.ark.spi.argument.CommandArgument;
+import com.alipay.sofa.ark.spi.tools.RuntimeUtil;
 import com.alipay.sofa.ark.support.thread.IsolatedThreadGroup;
 import com.alipay.sofa.ark.support.thread.LaunchRunner;
-import com.alipay.sofa.ark.common.util.AssertUtils;
-import sun.misc.URLClassPath;
-import com.alipay.sofa.ark.spi.argument.CommandArgument;
-import com.alipay.sofa.ark.bootstrap.ClasspathLauncher.ClassPathArchive;
 
-import java.lang.reflect.Field;
 import java.net.URL;
-import java.net.URLClassLoader;
 
 /**
  * relaunch a started main method with bootstrapping ark container
@@ -65,7 +63,7 @@ public class SofaArkBootstrap {
             /* default set sofa-ark log configuration to 'dev' mode when startup in IDE */
             System.setProperty("log.env.suffix", "com.alipay.sofa.ark:dev");
 
-            URL[] urls = getURLClassPath().getURLs();
+            URL[] urls = getURLClassPath();
             return new ClasspathLauncher(new ClassPathArchive(urls)).launch(getClasspath(urls));
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -79,7 +77,7 @@ public class SofaArkBootstrap {
         /* default set sofa-ark log configuration to 'dev' mode when startup in IDE */
         System.setProperty("log.env.suffix", "com.alipay.sofa.ark:dev");
 
-        URL[] urls = getURLClassPath().getURLs();
+        URL[] urls = getURLClassPath();
         new ClasspathLauncher(new ClassPathArchive(urls)).launch(args, getClasspath(urls),
             entryMethod.getMethod());
 
@@ -95,21 +93,10 @@ public class SofaArkBootstrap {
         return sb.toString();
     }
 
-    private static final URLClassPath getURLClassPath() throws Exception {
+    private static final URL[] getURLClassPath() throws Exception {
         try {
             ClassLoader classLoader = ClassLoader.getSystemClassLoader();
-            Field ucpField;
-
-            try {
-                /* JDK8 */
-                ucpField = classLoader.getClass().getDeclaredField("ucp");
-            } catch (NoSuchFieldException ex) {
-                /* JDK7 */
-                ucpField = URLClassLoader.class.getDeclaredField("ucp");
-            }
-
-            ucpField.setAccessible(true);
-            return (URLClassPath) ucpField.get(classLoader);
+            return RuntimeUtil.getClasspath(classLoader);
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Change the method of obtaining the classpath. The old method is to get the URLClassPath(ucp) field in the URLClassLoader. This class is a java class that is not recommended to be used and has no access in JDK9. Therefore, an equivalent implementation has been changed.