### PR TITLE
Change default classifier empty.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.alipay.sofa</groupId>
     <artifactId>sofa-ark</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sofa-ark-bom/pom.xml
+++ b/sofa-ark-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-parent/assembly/pom.xml
+++ b/sofa-ark-parent/assembly/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sofa-ark-all</artifactId>

--- a/sofa-ark-parent/core-impl/archive/pom.xml
+++ b/sofa-ark-parent/core-impl/archive/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-core-impl</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sofa-ark-archive</artifactId>

--- a/sofa-ark-parent/core-impl/container/pom.xml
+++ b/sofa-ark-parent/core-impl/container/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-core-impl</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sofa-ark-container</artifactId>

--- a/sofa-ark-parent/core-impl/pom.xml
+++ b/sofa-ark-parent/core-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sofa-ark-core-impl</artifactId>

--- a/sofa-ark-parent/core/common/pom.xml
+++ b/sofa-ark-parent/core/common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-core</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sofa-ark-common</artifactId>

--- a/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/EnvironmentUtils.java
+++ b/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/EnvironmentUtils.java
@@ -39,6 +39,10 @@ public class EnvironmentUtils {
         properties.setProperty(key, value);
     }
 
+    public static String clearProperty(String key) {
+        return System.clearProperty(key);
+    }
+
     public static void setSystemProperty(String key, String value) {
         System.setProperty(key, value);
     }

--- a/sofa-ark-parent/core/exception/pom.xml
+++ b/sofa-ark-parent/core/exception/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-core</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sofa-ark-exception</artifactId>

--- a/sofa-ark-parent/core/pom.xml
+++ b/sofa-ark-parent/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sofa-ark-core</artifactId>

--- a/sofa-ark-parent/core/spi/pom.xml
+++ b/sofa-ark-parent/core/spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-core</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sofa-ark-spi</artifactId>

--- a/sofa-ark-parent/pom.xml
+++ b/sofa-ark-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-bom</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
         <relativePath>../sofa-ark-bom</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-ark-parent/support/ark-maven-plugin/pom.xml
+++ b/sofa-ark-parent/support/ark-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-support</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>maven-plugin</packaging>

--- a/sofa-ark-parent/support/ark-plugin-maven-plugin/pom.xml
+++ b/sofa-ark-parent/support/ark-plugin-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-support</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-parent/support/ark-plugin-maven-plugin/src/main/java/com/alipay/sofa/ark/plugin/mojo/ArkPluginMojo.java
+++ b/sofa-ark-parent/support/ark-plugin-maven-plugin/src/main/java/com/alipay/sofa/ark/plugin/mojo/ArkPluginMojo.java
@@ -127,10 +127,15 @@ public class ArkPluginMojo extends AbstractMojo {
     @Parameter(defaultValue = "true")
     private Boolean                 attach;
 
+    /**
+     * default ark plugin artifact classifier: empty
+     */
+    @Parameter(defaultValue = "")
+    private String                  classifier;
+
     private static final String     ARCHIVE_MODE       = "zip";
     private static final String     PLUGIN_SUFFIX      = ".ark.plugin";
     private static final String     TEMP_PLUGIN_SUFFIX = ".ark.plugin.bak";
-    private static final String     PLUGIN_CLASSIFIER  = "ark-plugin";
 
     @SuppressWarnings("unchecked")
     @Override
@@ -178,7 +183,13 @@ public class ArkPluginMojo extends AbstractMojo {
             tmpDestination.delete();
         }
         if (isAttach()) {
-            projectHelper.attachArtifact(project, destination, getClassifier());
+            if (StringUtils.isEmpty(classifier)) {
+                Artifact artifact = project.getArtifact();
+                artifact.setFile(destination);
+                project.setArtifact(artifact);
+            } else {
+                projectHelper.attachArtifact(project, destination, classifier);
+            }
         }
     }
 
@@ -357,15 +368,6 @@ public class ArkPluginMojo extends AbstractMojo {
 
     protected String getTempFileName() {
         return String.format("%s%s", pluginName, TEMP_PLUGIN_SUFFIX);
-    }
-
-    /**
-     * default ark plugin artifact classifier: ark-plugin
-     *
-     * @return ark plugin artifact classifier
-     */
-    protected String getClassifier() {
-        return PLUGIN_CLASSIFIER;
     }
 
     /**

--- a/sofa-ark-parent/support/ark-springboot-starter/pom.xml
+++ b/sofa-ark-parent/support/ark-springboot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-support</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-parent/support/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/listener/ArkApplicationStartListener.java
+++ b/sofa-ark-parent/support/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/listener/ArkApplicationStartListener.java
@@ -16,7 +16,9 @@
  */
 package com.alipay.sofa.ark.springboot.listener;
 
+import com.alipay.sofa.ark.common.util.EnvironmentUtils;
 import com.alipay.sofa.ark.support.startup.SofaArkBootstrap;
+import com.alipay.sofa.common.log.Constants;
 import org.springframework.boot.context.event.ApplicationStartedEvent;
 import org.springframework.context.ApplicationListener;
 
@@ -33,6 +35,7 @@ public class ArkApplicationStartListener implements ApplicationListener<Applicat
     @Override
     public void onApplicationEvent(ApplicationStartedEvent event) {
         try {
+            EnvironmentUtils.clearProperty(Constants.LOG_PATH);
             if (shouldStartArk()) {
                 SofaArkBootstrap.launch(event.getArgs());
             }

--- a/sofa-ark-parent/support/ark-support-starter/pom.xml
+++ b/sofa-ark-parent/support/ark-support-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-support</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-parent/support/ark-tools/pom.xml
+++ b/sofa-ark-parent/support/ark-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-support</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sofa-ark-tools</artifactId>

--- a/sofa-ark-parent/support/pom.xml
+++ b/sofa-ark-parent/support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-samples/pom.xml
+++ b/sofa-ark-samples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>sofa-ark</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sofa-ark-samples</artifactId>

--- a/sofa-ark-samples/pom.xml
+++ b/sofa-ark-samples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>sofa-ark</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.1</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sofa-ark-samples</artifactId>
@@ -41,13 +41,6 @@
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>sample-ark-plugin</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.alipay.sofa</groupId>
-                <artifactId>sample-ark-plugin</artifactId>
-                <classifier>ark-plugin</classifier>
                 <version>${project.version}</version>
             </dependency>
 

--- a/sofa-ark-samples/pom.xml
+++ b/sofa-ark-samples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>sofa-ark</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.1-SNAPSHOT</version>
+        <version>0.4.1</version>
     </parent>
 
     <artifactId>sofa-ark-samples</artifactId>

--- a/sofa-ark-samples/sample-ark-plugin/README.md
+++ b/sofa-ark-samples/sample-ark-plugin/README.md
@@ -22,7 +22,7 @@
 <plugin>
     <groupId>com.alipay.sofa</groupId>
     <artifactId>sofa-ark-plugin-maven-plugin</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
 </plugin>
 ```
 
@@ -103,7 +103,7 @@
      <groupId>com.alipay.sofa</groupId>
      <artifactId>sample-ark-plugin</artifactId>
      <classifier>ark-plugin</classifier>
-     <version>0.4.0</version>
+     <version>0.4.1-SNAPSHOT</version>
  </dependency>
 ```
 

--- a/sofa-ark-samples/sample-ark-plugin/README_EN.md
+++ b/sofa-ark-samples/sample-ark-plugin/README_EN.md
@@ -111,6 +111,6 @@ should add the following dependency in your consumer project:
      <groupId>com.alipay.sofa</groupId>
      <artifactId>sample-ark-plugin</artifactId>
      <classifier>ark-plugin</classifier>
-     <version>0.4.0</version>
+     <version>0.4.1-SNAPSHOT</version>
  </dependency>
 ```

--- a/sofa-ark-samples/sample-ark-plugin/common/pom.xml
+++ b/sofa-ark-samples/sample-ark-plugin/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-sample-ark-plugin</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-samples/sample-ark-plugin/plugin/pom.xml
+++ b/sofa-ark-samples/sample-ark-plugin/plugin/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>sample-ark-plugin</artifactId>
 
+    <properties>
+        <ark.plugin.name>sample-ark-plugin</ark.plugin.name>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/sofa-ark-samples/sample-ark-plugin/plugin/pom.xml
+++ b/sofa-ark-samples/sample-ark-plugin/plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-sample-ark-plugin</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-samples/sample-ark-plugin/pom.xml
+++ b/sofa-ark-samples/sample-ark-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-samples</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-samples/sample-ark-plugin/pom.xml
+++ b/sofa-ark-samples/sample-ark-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-samples</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.1</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-samples/sample-ark-plugin/pom.xml
+++ b/sofa-ark-samples/sample-ark-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-samples</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.1-SNAPSHOT</version>
+        <version>0.4.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-samples/sample-springboot-ark/README.md
+++ b/sofa-ark-samples/sample-springboot-ark/README.md
@@ -11,7 +11,7 @@
 <plugin>
     <groupId>com.alipay.sofa</groupId>
     <artifactId>sofa-ark-maven-plugin</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
 </plugin>
 ```
 
@@ -32,7 +32,7 @@
      <groupId>com.alipay.sofa</groupId>
      <artifactId>sample-ark-plugin</artifactId>
      <classifier>ark-plugin</classifier>
-     <version>0.4.0</version>
+     <version>0.4.1-SNAPSHOT</version>
  </dependency>
 ```
 
@@ -87,7 +87,7 @@
 <dependency>
     <groupId>com.alipay.sofa</groupId>
     <artifactId>sofa-ark-springboot-starter</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -97,7 +97,7 @@
 <dependency>
     <groupId>com.alipay.sofa</groupId>
     <artifactId>sofa-ark-support-starter</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/sofa-ark-samples/sample-springboot-ark/README_EN.md
+++ b/sofa-ark-samples/sample-springboot-ark/README_EN.md
@@ -25,7 +25,7 @@ Add a dependency in main `pom.xml` as follows:
      <groupId>com.alipay.sofa</groupId>
      <artifactId>sample-ark-plugin</artifactId>
      <classifier>ark-plugin</classifier>
-     <version>0.4.0</version>
+     <version>0.4.1-SNAPSHOT</version>
  </dependency>
 ```
 
@@ -97,7 +97,7 @@ value of `outputDirectory`.
 
 ## run in command line
 we support command such as `java -jar executable-ark.jar` to startup application, similar to what this sample
-project does, execute command line: `java -jar target/sofa-ark-sample-springboot-ark-0.4.0-executable-ark.jar`
+project does, execute command line: `java -jar target/sofa-ark-sample-springboot-ark-0.4.1-SNAPSHOT-executable-ark.jar`
 to startup this demo. 
 
 ## run in IDE
@@ -110,7 +110,7 @@ you should add dependency as follows:
 <dependency>
     <groupId>com.alipay.sofa</groupId>
     <artifactId>sofa-ark-springboot-starter</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
 </dependency>
 ```
 + Common Java Project
@@ -120,7 +120,7 @@ you should add dependency as follows:
 <dependency>
     <groupId>com.alipay.sofa</groupId>
     <artifactId>sofa-ark-support-starter</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/sofa-ark-samples/sample-springboot-ark/pom.xml
+++ b/sofa-ark-samples/sample-springboot-ark/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-samples</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-samples/sample-springboot-ark/pom.xml
+++ b/sofa-ark-samples/sample-springboot-ark/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-samples</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.1</version>
+        <version>0.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -37,7 +37,6 @@
         <dependency>
             <groupId>com.alipay.sofa</groupId>
             <artifactId>sample-ark-plugin</artifactId>
-            <classifier>ark-plugin</classifier>
         </dependency>
 
         <!--test-->

--- a/sofa-ark-samples/sample-springboot-ark/pom.xml
+++ b/sofa-ark-samples/sample-springboot-ark/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-samples</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>0.4.1-SNAPSHOT</version>
+        <version>0.4.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
### Motivation:
Change default classifier empty.  Then users do not need specify classifier to import dependency.


